### PR TITLE
Changed table variable to object

### DIFF
--- a/timing.js
+++ b/timing.js
@@ -90,14 +90,13 @@
          * @param  Object opts Options (simple (bool) - opts out of full data view)
          */
         printTable: function(opts) {
-            var table = [];
+            var table = {};
             var data  = this.getTimes(opts);
             Object.keys(data).sort().forEach(function(k) {
-                table.push({
-                    label: k,
+                table[k] = {
                     ms: data[k],
                     s: +((data[k] / 1000).toFixed(2))
-                });
+                };
             });
             console.table(table);
         },


### PR DESCRIPTION
There is no reason to have an index column.
This PR removes the indexes replaces it with "labels". It's still sortable

Screenshot:
![screenshot](https://cloud.githubusercontent.com/assets/465996/4358824/69047c08-426d-11e4-8ecc-5fd42e641a5d.png)
