### PR TITLE
change annotate of initDomTreeTime and domReadyTime 

### DIFF
--- a/timing.js
+++ b/timing.js
@@ -67,7 +67,7 @@
 
                 // Total time from start to load
                 api.loadTime = timing.loadEventEnd - timing.fetchStart;
-                // Time spent constructing the DOM tree
+                // Time completion of the DOM loading
                 api.domReadyTime = timing.domComplete - timing.domInteractive;
                 // Time consumed preparing the new page
                 api.readyStart = timing.fetchStart - timing.navigationStart;
@@ -83,10 +83,12 @@
                 api.connectTime = timing.connectEnd - timing.connectStart;
                 // Time spent during the request
                 api.requestTime = timing.responseEnd - timing.requestStart;
-                // Request to completion of the DOM loading
+                // Time spent constructing the DOM tree
                 api.initDomTreeTime = timing.domInteractive - timing.responseEnd;
                 // Load event time
                 api.loadEventTime = timing.loadEventEnd - timing.loadEventStart;
+                // Dom can interacting time
+                api.interactingTime = timing.domContentLoadedEventEnd - timing.navigationStart
             }
 
             return api;


### PR DESCRIPTION
 - **api.domReadyTime**
i do not know the function of the domReadyTime, you say it measure the Time spending constructing the DOM tree. but the timing.domComplete means the time of total resources downloaded contaning images. and the timing.domLoading means the start time of constructing the DOM tree.
by reading http://calendar.perfplanet.com/2012/deciphering-the-critical-rendering-path/ ,the timing.domInteractive is the end time of constructing the DOM tree, including the synchronous javascript time. so i think timing.domInteractive - timing. responseEnd is more suitful as a function "Time spending constructing the DOM tree".
 - **api.interactingTime**
besides, i think we can add a attribute 'interactingTime', it uses to measure the time user can interacting with the page, 
eg 
![image](https://cloud.githubusercontent.com/assets/8492963/11015852/0a531ee6-85a9-11e5-83b5-b2db093397ce.png)
two numbers are almost same!