### PR TITLE
Fix broken window object in browser-side commonjs environment

### DIFF
--- a/timing.js
+++ b/timing.js
@@ -119,4 +119,9 @@
         return !isNaN(parseFloat(n)) && isFinite(n);
     }
 
-})(this);
+    // Expose as a commonjs module
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = window.timing;
+    }
+
+})(typeof window !== 'undefined' ? window : {});


### PR DESCRIPTION
In [browserify](https://github.com/substack/node-browserify) context, `this` is not a `Window` object on commonjs module.
So, when we use browserify, timing.js cannot find `window.performance` properly and `getTimes()` always returns `false`.

I fixed this by exporting module via `module.exports` explicitly instead of using `this`.