### PR TITLE
readme: Fix unloadEventTime typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ timing.js
 
 * Normalizes `firstPaint` across Chrome, Opera and IE11 to `timing.getTimes().firstPaint`. Firefox may be able to do similar with `MozAfterPaint`
 * Adds `firstPaintTime` (`firstPaint` - load/nav start)
-* Adds:`domReadyTime`, `initDomTreeTime`, `loadEventTime`, `loadTime`, `redirectTime`, `requestTime`, `uploadEventTime` `connectTime`
+* Adds:`domReadyTime`, `initDomTreeTime`, `loadEventTime`, `loadTime`, `redirectTime`, `requestTime`, `unloadEventTime` `connectTime`
 
 ## Installation
 


### PR DESCRIPTION
Fixes https://github.com/addyosmani/timing.js/issues/27.

Extracted from https://github.com/addyosmani/timing.js/pull/32 (which contained an unrelated commit).